### PR TITLE
faster lzw decode

### DIFF
--- a/lzw.py
+++ b/lzw.py
@@ -67,9 +67,8 @@ def flip_data(compress_data):
         fliped_data += compress_data[-8:]
         compress_data = compress_data[:-8]
 
-    bytes_object = fliped_data.encode("utf-8")
 
-    return bytes_object
+    return fliped_data.encode("utf-8")
 
 
 def get_encode_element(stream, reading_size):
@@ -190,8 +189,7 @@ def get_decode_element(stream, reading_size, pos):
     :return: element
     """
     stream.pos = pos
-    element = stream.read('bin' + str(reading_size))
-    return int(element, 2)
+    return stream.read(f'uint{reading_size}')
 
 
 def index_to_binary(element, writing_size):
@@ -257,17 +255,7 @@ def decode_lzw(compressed_data, lzw_minimum_code_size):
     #  add the enf of reading
     end_of_information_code = int(table[(len(table) - 1)])
 
-    #bytes_object = bytes.fromhex(compressed_data)
-    bytes_object = compressed_data
-
-    # Convert bytes object to binary string with leading zeros
-    binary_string = ''.join(format(byte, '08b') for byte in bytes_object)
-
-    compressed_data = flip_data(binary_string)
-    data_length = len(compressed_data)
-    compressed_data = hex(int(compressed_data, 2))
-    compressed_data = fill_zero_hexa(compressed_data, data_length)
-    stream = ConstBitStream(compressed_data)
+    stream = ConstBitStream(compressed_data[::-1])
     pos = stream.length - reading_size
     first_element = get_decode_element(stream, reading_size, pos)
     pos = pos - reading_size

--- a/lzw.py
+++ b/lzw.py
@@ -166,7 +166,7 @@ def encode(uncompressed_data, color_table_size):
     return res
 
 
-def read_next_uint(stream, reading_size) -> int:
+def get_decode_element(stream, reading_size) -> int:
     stream.pos -= reading_size
     value: int = stream.read(f'uint{reading_size}')
     stream.pos -= reading_size
@@ -244,23 +244,23 @@ def decode_lzw(compressed_data, lzw_minimum_code_size):
     # stream2 = ConstBitStream(bits)
 
     stream.pos = stream.length
-    first_element = read_next_uint(stream, reading_size)
+    first_element = get_decode_element(stream, reading_size)
 
     if first_element != clear_code:
         print("the image was corrupted")
         return -1
 
     decompressed_data = io.BytesIO()
-    curr_el = read_next_uint(stream, reading_size)
+    curr_el = get_decode_element(stream, reading_size)
     decompressed_data.write(index_to_binary(table[curr_el], writing_size))
     while True:
-        next_el = read_next_uint(stream, reading_size)
+        next_el = get_decode_element(stream, reading_size)
         if next_el == end_of_information_code:
             break
         if next_el == clear_code:
             table = initialize_code_table(int(color_table_size), True)
             reading_size = lzw_minimum_code_size + 1
-            curr_el = read_next_uint(stream, reading_size)
+            curr_el = get_decode_element(stream, reading_size)
             decompressed_data.write(index_to_binary(table[curr_el], writing_size))
 
             continue

--- a/main.py
+++ b/main.py
@@ -9,6 +9,14 @@ def main(filename: str, *, show_image: bool = False):
         gif: Gif = decode_gif(gif_file)
         print("decoded")
 
+    # with open(filename, "rb") as gif_file:
+    #     original = bitstring.ConstBitStream(gif_file)
+    #
+    # with open("result.gif", "rb") as gif_file:
+    #     saved: Gif = decode_gif(gif_file)
+
+    # saved.print_diff(gif)
+
     pprint(gif)
     if show_image:
         for image in gif.images:
@@ -21,4 +29,4 @@ def main(filename: str, *, show_image: bool = False):
 
 
 if __name__ == '__main__':
-    main("gif_tests/test4.gif", show_image=True)
+    main("gif_tests/test3.gif", show_image=True)

--- a/main.py
+++ b/main.py
@@ -9,22 +9,15 @@ def main(filename: str, *, show_image: bool = False):
         gif: Gif = decode_gif(gif_file)
         print("decoded")
 
-    # with open("result.gif", "wb") as f:
-    #     res = write_gif(gif)
-    #     res._stream.tofile(f)
-
-    # with open(filename, "rb") as gif_file:
-    #     original = bitstring.ConstBitStream(gif_file)
-    #
-    # with open("result.gif", "rb") as gif_file:
-    #     saved: Gif = decode_gif(gif_file)
-
-    # saved.print_diff(gif)
-
     pprint(gif)
     if show_image:
         for image in gif.images:
             image.img.show()
+
+    with open("result.gif", "wb") as f:
+        res = write_gif(gif)
+        res._stream.tofile(f)
+        print("saved")
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -29,4 +29,4 @@ def main(filename: str, *, show_image: bool = False):
 
 
 if __name__ == '__main__':
-    main("gif_tests/test3.gif", show_image=True)
+    main("gif_tests/giphy.gif", show_image=True)

--- a/main.py
+++ b/main.py
@@ -9,9 +9,9 @@ def main(filename: str, *, show_image: bool = False):
         gif: Gif = decode_gif(gif_file)
         print("decoded")
 
-    with open("result.gif", "wb") as f:
-        res = write_gif(gif)
-        res._stream.tofile(f)
+    # with open("result.gif", "wb") as f:
+    #     res = write_gif(gif)
+    #     res._stream.tofile(f)
 
     # with open(filename, "rb") as gif_file:
     #     original = bitstring.ConstBitStream(gif_file)
@@ -28,4 +28,4 @@ def main(filename: str, *, show_image: bool = False):
 
 
 if __name__ == '__main__':
-    main("gif_tests/test4.gif", show_image=False)
+    main("gif_tests/test4.gif", show_image=True)

--- a/main.py
+++ b/main.py
@@ -9,14 +9,6 @@ def main(filename: str, *, show_image: bool = False):
         gif: Gif = decode_gif(gif_file)
         print("decoded")
 
-    # with open(filename, "rb") as gif_file:
-    #     original = bitstring.ConstBitStream(gif_file)
-    #
-    # with open("result.gif", "rb") as gif_file:
-    #     saved: Gif = decode_gif(gif_file)
-
-    # saved.print_diff(gif)
-
     pprint(gif)
     if show_image:
         for image in gif.images:

--- a/preformance_tests/profiling.py
+++ b/preformance_tests/profiling.py
@@ -6,15 +6,15 @@ from typing import Callable, Literal
 import main
 
 
-def profile(function: Callable, tool: Literal['snakeviz', 'tuna'], *args, **kwargs):
+def profile(tool: Literal['snakeviz', 'tuna'], function: Callable, *args, **kwargs):
     with cProfile.Profile() as pr:
         function(*args, **kwargs)
 
     stats = pstats.Stats(pr)
     stats.sort_stats(pstats.SortKey.TIME)
-    stats.dump_stats(filename='../profiling.prof')
+    stats.dump_stats(filename='profiling.prof')
     subprocess.run([tool, 'profiling.prof'])
 
 
 if __name__ == '__main__':
-    profile(main.main, 'snakeviz', "gif_tests/test4.gif", show_image=False)
+    profile('tuna', main.main, "../gif_tests/test4.gif", show_image=False)

--- a/test.py
+++ b/test.py
@@ -29,6 +29,10 @@ def check_read(path: Path):
 
     print(f"file {path.stem} correctness: {current == saved}")
 
+def load_gif(path: Path) -> Gif:
+    with open(path.with_suffix('.pickle'), 'rb') as pickle_file:
+        return pickle.load(pickle_file)
+
 
 def save_file(path: Path):
     try:
@@ -67,4 +71,4 @@ def test_gifs(*, mode: Literal['save', 'check_read', 'check_write'], files: list
 
 
 if __name__ == '__main__':
-    test_gifs(mode='check_write', files=['test4'])
+    test_gifs(mode='save', files=['giphy2'])


### PR DESCRIPTION
big changes:
1. removed flip data and zero padding, now reversing the bytes and sending to BitStream
2. (does not help in performance but readability) inserted the pos changes to get_decode_element
3. changed bytes concatenating from b"" += to BinaryIO.write
4. in initialize_code_table removed the unnecessary reversing of the dice if in decode (just re-wrote the creation)

explanation:
1. unnecessary calculation, reversing in chunks of 8 on the binary form of bytes =is the same as= reversing the byte string since chunk of 8 bits is byte. padding is probably unnecessary since reversing does not remove leading zeros (and converting to int does that's why you needed in the original version), and BitStream is smart enough to read bytes so converting to hex is also unnecessary.
2. does not improve performance, but readability
3. in python strings (and bytes strings) are immutable, so doing "a"+"b" is actually creating third string, in 2 variables this is negligent, but in while loop it adds up, StringIO (and BinaryIO) are [Buffered Streams](https://docs.python.org/3/library/io.html#buffered-streams) which implement the file interface and allow concatenating without copying (using "".join(list) is faster but does not suitable for this use case)
4. if in decode, initialize_code_table creates 2 dict overall, but the second is based on the first one, so removed this coupling, 


* seems to work for all gifs i checked, need to add precise test
* still did not understand and went through the while loop and logic
* changes i did not wrote here, are small, insignificant and manly for my readability