### PR TITLE
Faster encode

### DIFF
--- a/lzw.py
+++ b/lzw.py
@@ -18,6 +18,14 @@ def write_compressed_data(result: [str], code_size: int):
 
 
 def insert_to_stream(stream: BitArray, value: int, bits: int) -> None:
+    """
+    prepend takes a lot of time, optional implementation is to add to the end the bits, but add right rotation of bits%8
+    (under the assumption of bits < 16)
+    :param stream:
+    :param value:
+    :param bits:
+    :return:
+    """
     stream.prepend(f"uint:{bits}={value}")
 
 
@@ -59,12 +67,6 @@ def flip_data(compress_data):
 
 
 def get_encode_element(stream, reading_size):
-    """
-    the next element represent in as string number . the riding size in constant
-    :param stream:
-    :param reading_size:
-    :return: element
-    """
     value: int = stream.read(f"uint:{reading_size}")
     return str(value)
 

--- a/main.py
+++ b/main.py
@@ -20,4 +20,4 @@ def main(filename: str, *, show_image: bool = False):
 
 
 if __name__ == '__main__':
-    main("gif_tests/test3.gif", show_image=False)
+    main("gif_tests/test4.gif", show_image=False)

--- a/main.py
+++ b/main.py
@@ -20,4 +20,4 @@ def main(filename: str, *, show_image: bool = False):
 
 
 if __name__ == '__main__':
-    main("gif_tests/giphy.gif", show_image=False)
+    main("gif_tests/test3.gif", show_image=False)

--- a/preformance_tests/profiling.py
+++ b/preformance_tests/profiling.py
@@ -17,4 +17,4 @@ def profile(tool: Literal['snakeviz', 'tuna'], function: Callable, *args, **kwar
 
 
 if __name__ == '__main__':
-    profile('tuna', main.main, "../gif_tests/giphy.gif", show_image=False)
+    profile('tuna', main.main, "../gif_tests/test4.gif", show_image=False)

--- a/writer.py
+++ b/writer.py
@@ -16,6 +16,7 @@ def convert_int_to_bits(number, code_size):
 
 def index_from_data(image_data, color_table):
     size_of_index = math.ceil(math.log(len(color_table), 2)) + 1
+    # TODO: switch to use bitstring.stream
     indexes = [convert_int_to_bits(color_table.index(color), size_of_index) for color in image_data]
     res = b''.join(indexes)
     hex_string = '0x' + hex(int(res.decode('utf-8'), 2))[2:]

--- a/writer.py
+++ b/writer.py
@@ -3,12 +3,15 @@ import math
 from BitStream import BitStreamWriter
 from enums import BlockPrefix
 from gif_objects import Gif, ApplicationExtension, GraphicControlExtension, Image, CommentExtension, PlainTextExtension
-from lzw import convert_int_to_bits, encode
+from lzw import insert_to_stream, encode
 from utils import chunker
 
 ApplicationExtensionBlockSize = 11
 GraphicControlExtensionBlockSize = 4
 PlainTextExtensionBlockSize = 4
+
+def convert_int_to_bits(number, code_size):
+    return bytes((bin(number)[2:]).zfill(code_size), 'utf-8')
 
 
 def index_from_data(image_data, color_table):


### PR DESCRIPTION
### changes:
instead of concatenating using bytes string (which are immutable) switched to use BitArray of Bitstring which allows inserting at the start any value (and specifically uint which is what we want). at the end of the function reversed the bytes (called bytesswap) and returned the bytes. 
* changed int to bits function to the insert function (and the name)
* inserting at the start is expensive operation, there is possible another faster implementation that may work, wrote psedu-code in comment

### other possible improvements
1. in dict, storing the numbers in tuple instead of string
2. in index to data function (or data to index whatever) remove the conversion to hex and change to use bitstring.stream